### PR TITLE
FIX issue name_regex parameter in datasource zones and specs is unavailable 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 1.0.1 (Unreleased)
+
+BUG FIXES:
+- datasource/baiducloud_zones: Fix the problems of unavailable parameter "name_regex" ([#1](https://github.com/terraform-providers/terraform-provider-baiducloud/issues/1))
+- datasource/baiducloud_specs: Fix the problems of unavailable parameter "name_regex" ([#1](https://github.com/terraform-providers/terraform-provider-baiducloud/issues/1))
+
 ## 1.0.0 (February 19, 2020)
 
 FEATURES:

--- a/baiducloud/data_source_baiducloud_specs.go
+++ b/baiducloud/data_source_baiducloud_specs.go
@@ -112,14 +112,14 @@ func dataSourceBaiduCloudSpecsRead(d *schema.ResourceData, meta interface{}) err
 	}
 	addDebug(action, raw)
 
-	var specName, instanceType string
+	var nameRegex, instanceType string
 	var cpuCount, memorySizeInGb int
 	var specNameRegex *regexp.Regexp
 
-	if value, ok := d.GetOk("spec_name"); ok {
-		specName = value.(string)
-		if len(specName) > 0 {
-			specNameRegex = regexp.MustCompile(specName)
+	if value, ok := d.GetOk("name_regex"); ok {
+		nameRegex = value.(string)
+		if len(nameRegex) > 0 {
+			specNameRegex = regexp.MustCompile(nameRegex)
 		}
 	}
 
@@ -138,7 +138,7 @@ func dataSourceBaiduCloudSpecsRead(d *schema.ResourceData, meta interface{}) err
 	response := raw.(*api.ListSpecResult)
 	specMap := make([]map[string]interface{}, 0, len(response.InstanceTypes))
 	for _, spec := range response.InstanceTypes {
-		if len(specName) > 0 && specNameRegex != nil {
+		if len(nameRegex) > 0 && specNameRegex != nil {
 			if !specNameRegex.MatchString(spec.Name) {
 				continue
 			}

--- a/baiducloud/data_source_baiducloud_zones.go
+++ b/baiducloud/data_source_baiducloud_zones.go
@@ -74,20 +74,20 @@ func dataSourceBaiduCloudZonesRead(d *schema.ResourceData, meta interface{}) err
 	}
 	addDebug(action, raw)
 
-	var zoneName string
+	var nameRegexStr string
 	var zoneNameRegex *regexp.Regexp
 
-	if value, ok := d.GetOk("zone_name"); ok {
-		zoneName = value.(string)
-		if len(zoneName) > 0 {
-			zoneNameRegex = regexp.MustCompile(zoneName)
+	if value, ok := d.GetOk("name_regex"); ok {
+		nameRegexStr = value.(string)
+		if len(nameRegexStr) > 0 {
+			zoneNameRegex = regexp.MustCompile(nameRegexStr)
 		}
 	}
 
 	response := raw.(*api.ListZoneResult)
 	zoneMap := make([]map[string]interface{}, 0, len(response.Zones))
 	for _, zone := range response.Zones {
-		if len(zoneName) > 0 && zoneNameRegex != nil {
+		if len(nameRegexStr) > 0 && zoneNameRegex != nil {
 			if !zoneNameRegex.MatchString(zone.ZoneName) {
 				continue
 			}


### PR DESCRIPTION
bug fix
FIX issue name_regex parameter in datasource zones and specs is unavailable
https://github.com/terraform-providers/terraform-provider-baiducloud/issues/1