### PR TITLE
Fix issue that the vpc_id of datasource vpcs cannot be empty in tf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 BUG FIXES:
 - datasource/baiducloud_zones: Fix the problems of unavailable parameter "name_regex" ([#1](https://github.com/terraform-providers/terraform-provider-baiducloud/issues/1))
 - datasource/baiducloud_specs: Fix the problems of unavailable parameter "name_regex" ([#1](https://github.com/terraform-providers/terraform-provider-baiducloud/issues/1))
+- datasource/baiducloud_vpcs: Fix the problems of parameter "vpc_id" in tf cannot be empty. ([#4](https://github.com/terraform-providers/terraform-provider-baiducloud/issues/4))
 
 ## 1.0.0 (February 19, 2020)
 

--- a/baiducloud/data_source_baiducloud_vpcs.go
+++ b/baiducloud/data_source_baiducloud_vpcs.go
@@ -141,7 +141,7 @@ func dataSourceBaiduCloudVpcsRead(d *schema.ResourceData, meta interface{}) erro
 		vpcMap["secondary_cidrs"] = vpc.SecondaryCidr
 		vpcMap["tags"] = flattenTagsToMap(vpc.Tags)
 
-		res, err := vpcService.GetRouteTableDetail("", vpcId)
+		res, err := vpcService.GetRouteTableDetail("", vpc.VPCID)
 		if err != nil {
 			return WrapErrorf(err, DefaultErrorMsg, "baiducloud_vpc", action, BCESDKGoERROR)
 		}


### PR DESCRIPTION
Fix issue that the vpc_id of datasource vpcs cannot be empty in tf.
#4 